### PR TITLE
add link to updated screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ asreview oracle
 
 The datasets are selectable in Step 2 of the project initialization. For more information on the usage of ASReview, please have a look at the [Quick Tour](https://asreview.readthedocs.io/en/latest/quicktour.html). 
 
-[![ASReview CORD19 datasets](https://github.com/asreview/asreview/blob/master/images/asrewiew-plugin-cord19-dataset.png?raw=true)](https://github.com/asreview/asreview-covid19)
+[![ASReview CORD19 datasets](https://github.com/asreview/asreview/blob/master/images/asreview-covid19-screenshot.png?raw=true)](https://github.com/asreview/asreview-covid19)
 
 ## License and contact
 


### PR DESCRIPTION
Update outdated screenshot of selecting CORD-19 database. 

The image is located in the asreview/asreview repo, therefore this pr goes along with [this one](https://github.com/asreview/asreview/pull/241 ). 

Solves issue #12