### PR TITLE
Add CI pipeline, add tests and rename dataset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: test-plugin
+on: [push, pull_request]
+jobs:
+  test:
+    name: pytest
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions/setup-python@v1
+      with:
+        python-version: '3.6'
+        architecture: 'x64'
+    - name: Install packages
+      run: |
+        pip install .
+    - name: Test packages
+        pytest tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
     - name: Install packages
       run: |
         pip install .
+        pip install pytest
     - name: Test packages
       run: |
         pytest tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,4 +14,5 @@ jobs:
       run: |
         pip install .
     - name: Test packages
+      run: |
         pytest tests

--- a/config/cord19-all/index.json
+++ b/config/cord19-all/index.json
@@ -1,6 +1,6 @@
 {
     "title": "CORD-19",
-    "base_id": "cord19",
+    "base_id": "cord19-all",
     "type": "versioned",
     "filenames": [
         "cord19_v3_all.json",

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,20 +1,38 @@
 from pytest import mark
 import urllib
 
-from asreview.datasets import get_dataset
+from asreview.datasets import get_available_datasets
+from asreview.datasets import find_data
 
 
-def exists(url):
+ASREVIEW_COVID19_DATASET_COLLECTIONS = [
+    "cord19-all",
+    "cord19-2020",
+]
+
+
+def _dataset_url_exists(url):
     return urllib.request.urlopen(url).getcode() == 200
 
 
 @mark.parametrize(
-    "data_name",
-    [
-        "cord19_all",
-        "cord19_after_dec19",
-    ]
+    "data_name", ASREVIEW_COVID19_DATASET_COLLECTIONS
 )
-def test_datasets(data_name):
-    data = get_dataset(data_name)
-    assert exists(data.get())
+def test_find_datasets(data_name):
+    data = find_data(data_name)
+
+    assert _dataset_url_exists(data)
+
+
+def test_get_available_datasets():
+
+    datasets = get_available_datasets()
+
+    for key in ASREVIEW_COVID19_DATASET_COLLECTIONS:
+
+        assert key in datasets['covid19'].keys()
+
+        for dataset in datasets['covid19'][key].list():
+            assert dataset.title is not None
+            assert dataset.url is not None
+            assert dataset.dataset_id is not None


### PR DESCRIPTION
This PR implements a CI pipeline and more tests. This should prevent unexpected behaviour when adding new datasets. 

The dataset `cord19` is renamed into `cord19-all` to match the folder structure. ﻿
