### PR TITLE
Deprecate ASReview-covid19

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 Extension to add publications on COVID-19 to [ASReview](https://github.com/asreview/asreview).
 
-# ASReview against COVID-19
+# ASReview against COVID-19 (Deprecated)
+
+## This extension is deprecated. It still works for version 0.x of ASReview but datasets are no longer updated.
 
 [![Downloads](https://pepy.tech/badge/asreview-covid19)](https://pepy.tech/project/asreview-covid19) [![PyPI version](https://badge.fury.io/py/asreview-covid19.svg)](https://badge.fury.io/py/asreview-covid19) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3764749.svg)](https://doi.org/10.5281/zenodo.3764749) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         #   3 - Alpha
         #   4 - Beta
         #   5 - Production/Stable
-        'Development Status :: 4 - Beta',
+        'Development Status :: 7 - Inactive',
 
         # Pick your license as you wish
         'License :: OSI Approved :: Apache Software License',

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
     packages=find_namespace_packages(include=['asreviewcontrib.*']),
     namespace_package=["asreview"],
     install_requires=[
-        "asreview>=0.9.4",
+        "asreview<1.0",
     ],
 
     extras_require=DEPS,


### PR DESCRIPTION
This PR proposes to deprecate the asreview-covid19 plugin. The plugin can still be used but is no longer updated. The size of the datasets has become very large and users are recommended to use scientific search engines to search and compose a dataset. 